### PR TITLE
Add links to other repos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Hosted here: http://endurojs.com/
 
+**Other repositories:** [Enduro](https://github.com/Gottwik/Enduro) • [samples](https://github.com/Gottwik/enduro_samples) • [Enduro admin](https://github.com/Gottwik/enduro_admin) • endurojs.com site
+
 ![Imgur](http://i.imgur.com/NM9ZODP.png)
 
 # Contributing


### PR DESCRIPTION
This and other recent pull requests simply add wiki-like links to other enduro repos.

> I often find myself navigating between these repos through @Gottwik profile :)
> I feel they should be linked to each other 'cause enduro admin and enduro itself are too tied to each 
other, and linking to samples and website enables better onboarding.

Other PRs: https://github.com/Gottwik/Enduro/pull/75 • https://github.com/Gottwik/enduro_samples/pull/1 • https://github.com/Gottwik/enduro_admin/pull/10